### PR TITLE
Add support native window.Promise without wrap

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -39,7 +39,7 @@
     opts = opts || {};
 
     this._id        = CrossStorageClient._generateUUID();
-    this._promise   = opts.promise || Promise;
+    this._promise   = (typeof Promise !== 'undefined') ? Promise : opts.promise;
     this._frameId   = opts.frameId || 'CrossStorageClient-' + this._id;
     this._origin    = CrossStorageClient._getOrigin(url);
     this._requests  = {};


### PR DESCRIPTION
Could we use window.Promise without such wrapper in users code:

var storage = new CrossStorageClient('http://localhost:3000/hub.html', {
  promise: (typeof Promise !== 'undefined') ? Promise : require('es6-promise').Promise
});