### PR TITLE
Removed named module as this causes portability issues when using r.js

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -437,7 +437,7 @@
   } else if (typeof exports !== 'undefined') {
     exports.CrossStorageClient = CrossStorageClient;
   } else if (typeof define === 'function' && define.amd) {
-    define('CrossStorageClient', [], function() {
+    define([], function() {
       return CrossStorageClient;
     });
   } else {

--- a/lib/hub.js
+++ b/lib/hub.js
@@ -261,7 +261,7 @@
   } else if (typeof exports !== 'undefined') {
     exports.CrossStorageHub = CrossStorageHub;
   } else if (typeof define === 'function' && define.amd) {
-    define('CrossStorageHub', [], function() {
+    define([], function() {
       return CrossStorageHub;
     });
   } else {


### PR DESCRIPTION
Require-config should specify location and name of module by filename

This allows you to use path config to specify directory and name is defined by filename for example define(['cross-storage/hub'], function(hub){ ... });
define(['cross-storage/client'], function(client){ ... });

Otherwise you have to make path config entries for each file, this is also more inline with commonjs naming conventions