### PR TITLE
add entry-point files for HTML imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ If using inline JS to create the hub, you'll need to specify `unsafe-inline`
 for the CSP headers. Otherwise, it can be left out if simply including the
 init code via another resource.
 
+#### Web Component wrapper
+
+`CrossStorageClient` has a Web Component wrapper, built with Polymer. For more information go [here](https://github.com/firmfirm/f-cross-storage).
+
 ## API
 
 #### CrossStorageHub.init(permissions)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cross-storage",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Cross domain local storage",
   "license": "Apache-2.0",
   "authors": [

--- a/imports/client.html
+++ b/imports/client.html
@@ -1,0 +1,2 @@
+<!-- To be used for HTML Imports -->
+<script src="../dist/client.min.js"></script>

--- a/imports/hub.html
+++ b/imports/hub.html
@@ -1,0 +1,2 @@
+<!-- To be used for HTML Imports -->
+<script src="../dist/hub.min.js"></script>


### PR DESCRIPTION
These new files are needed when using with web components. HTML imports is a standard and ensures that it's only loaded once (in case different components have the same import)