### PR TITLE
fix json parse and split not defined issues

### DIFF
--- a/lib/hub.js
+++ b/lib/hub.js
@@ -79,7 +79,18 @@
     // Ignore the ready message when viewing the hub directly
     if (message.data === 'cross-storage:ready') return;
 
-    request = JSON.parse(message.data);
+    // Check whether message.data is a valid json
+    try {
+      request = JSON.parse(message.data);
+    } catch (err) {
+      return;
+    }
+
+    // Check whether request.method is a string
+    if (!request && typeof request.method !== 'string') {
+      return;
+    }
+    
     method = request.method.split('cross-storage:')[1];
 
     if (!method) {

--- a/lib/hub.js
+++ b/lib/hub.js
@@ -87,10 +87,10 @@
     }
 
     // Check whether request.method is a string
-    if (!request && typeof request.method !== 'string') {
+    if (!request || typeof request.method !== 'string') {
       return;
     }
-    
+
     method = request.method.split('cross-storage:')[1];
 
     if (!method) {


### PR DESCRIPTION
the problem is, that "window.addEventListener('message', listener, false)" attached to all "message" events, that will be triggered on hubs window and it is possible, that some other modules calls "postMessage" on hub, so following errors shows up on the browser console:

Example: $("#CrossStorageClient-XXX")[0].contentWindow.postMessage("bla", "http://localhost")
Error: Uncaught SyntaxError: Unexpected token br._listener @ xshub:11

or

Example: $("#CrossStorageClient-XXX")[0].contentWindow.postMessage('{"bla":"bla"}', "http://localhost")
Error: Uncaught TypeError: Cannot read property 'split' of undefinedr._listener @ xshub:11



