### PR TITLE
Prevent JSON parse error on _get

### DIFF
--- a/lib/hub.js
+++ b/lib/hub.js
@@ -188,7 +188,12 @@
 
     for (i = 0; i < params.keys.length; i++) {
       key = params.keys[i];
-      item = JSON.parse(storage.getItem(key));
+      
+      try {
+        item = JSON.parse(storage.getItem(key));
+      } catch (e) {
+        item = null;
+      }
 
       if (item === null) {
         result.push(null);


### PR DESCRIPTION
In order to prevent JSON parse error on `_get`, I suggest to put the item parsing `JSON.parse(storage.getItem(key));` on a try-catch and set the item value to `null` if the parsing fail.

This error occur when the localstorage is used by the cross-storage module (which set the localstorage value into an object like `{"value":null}`) an a native usage of the localstorage (which not necessary set the localstorage value into an object and will break the JSON parsing).