### PR TITLE
Adds `rawMode` to disable serializing localStorage values

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -22,7 +22,7 @@
    *
    * @param {string} url    The url to a cross storage hub
    * @param {object} [opts] An optional object containing additional options,
-   *                        including timeout, frameId, and promise
+   *                        including timeout, frameId, promise, and raw mode
    *
    * @property {string}   _id        A UUID v4 id
    * @property {function} _promise   The Promise object to use
@@ -33,6 +33,7 @@
    * @property {bool}     _closed    Whether or not the client has closed
    * @property {int}      _count     Number of requests sent
    * @property {function} _listener  The listener added to the window
+   * @property {bool}     _rawMode   Whether or not to serialize on the hub
    * @property {Window}   _hub       The hub window
    */
   function CrossStorageClient(url, opts) {
@@ -48,6 +49,7 @@
     this._count     = 0;
     this._timeout   = opts.timeout || 5000;
     this._listener  = null;
+    this._rawMode   = opts.rawMode || false;
 
     this._installListener();
 
@@ -173,11 +175,16 @@
    * @returns {Promise} A promise that is settled on hub response or timeout
    */
   CrossStorageClient.prototype.set = function(key, value, ttl) {
-    return this._request('set', {
-      key:   key,
-      value: value,
-      ttl:   ttl
-    });
+    if (this._rawMode && ttl) {
+      return reject(new Error('You cannot use ttls in raw mode.'));
+    } else {
+      return this._request('set', {
+        key:   key,
+        value: value,
+        ttl:   ttl,
+        raw: this._rawMode
+      });
+    }
   };
 
   /**
@@ -193,7 +200,7 @@
   CrossStorageClient.prototype.get = function(key) {
     var args = Array.prototype.slice.call(arguments);
 
-    return this._request('get', {keys: args});
+    return this._request('get', {keys: args, raw: this._rawMode});
   };
 
   /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -175,16 +175,12 @@
    * @returns {Promise} A promise that is settled on hub response or timeout
    */
   CrossStorageClient.prototype.set = function(key, value, ttl) {
-    if (this._rawMode && ttl) {
-      return reject(new Error('You cannot use ttls in raw mode.'));
-    } else {
-      return this._request('set', {
-        key:   key,
-        value: value,
-        ttl:   ttl,
-        raw: this._rawMode
-      });
-    }
+    return this._request('set', {
+      key:   key,
+      value: value,
+      ttl:   ttl,
+      raw: this._rawMode
+    });
   };
 
   /**
@@ -398,6 +394,10 @@
 
     if (this._closed) {
       return this._promise.reject(new Error('CrossStorageClient has closed'));
+    }
+
+    if (method === 'set' && params.ttl && params.raw) {
+      return this._promise.reject(new Error('cannot set TTL with raw mode'));
     }
 
     client = this;

--- a/lib/hub.js
+++ b/lib/hub.js
@@ -156,7 +156,7 @@
    * @param {object} params An object with key, value and optional ttl
    */
   CrossStorageHub._set = function(params) {
-    var ttl, item;
+    var ttl, item, setValue;
 
     ttl = params.ttl;
     if (ttl && parseInt(ttl, 10) !== ttl) {
@@ -168,7 +168,9 @@
       item.expire = CrossStorageHub._now() + ttl;
     }
 
-    window.localStorage.setItem(params.key, JSON.stringify(item));
+    setValue = params.raw ? params.value : JSON.stringify(item);
+
+    window.localStorage.setItem(params.key, setValue);
   };
 
   /**
@@ -188,9 +190,9 @@
 
     for (i = 0; i < params.keys.length; i++) {
       key = params.keys[i];
-      
+
       try {
-        item = JSON.parse(storage.getItem(key));
+        item = params.raw ? storage.getItem(key) : JSON.parse(storage.getItem(key));
       } catch (e) {
         item = null;
       }
@@ -201,9 +203,12 @@
         storage.removeItem(key);
         result.push(null);
       } else {
-        result.push(item.value);
+        var pushValue = params.raw ? item : item.value;
+        result.push(pushValue);
       }
     }
+
+    console.log(result);
 
     return (result.length > 1) ? result : result[0];
   };

--- a/test/test.js
+++ b/test/test.js
@@ -80,6 +80,11 @@ describe('CrossStorageClient', function() {
       expect(storage._timeout).to.be(10000);
     });
 
+    it('sets rawMode to opts.rawMode, if provided', function() {
+        var storage = new CrossStorageClient(url, {rawMode: true});
+        expect(storage._rawMode).to.be(true);
+    })
+
     it('sets its connected status to false', function() {
       var storage = new CrossStorageClient(url);
       expect(storage._connected).to.be(false);
@@ -250,6 +255,19 @@ describe('CrossStorageClient', function() {
         expect(res).to.eql(object);
         done();
       })['catch'](done);
+    });
+
+    it('can set raw values instead of serializing in raw mode', function(done) {
+        var key = 'key1';
+        var value = 'foo';
+
+        var storage = new CrossStorageClient(url, { rawMode: true });
+        storage.onConnect()
+        .then(setGet(key, value))
+        .then(function(res) {
+            expect(res).to.eql(value);
+            done();
+        })['catch'](done);
     });
 
     it('can overwrite existing values', function(done) {


### PR DESCRIPTION
We've been integrating cross-storage with a localStorage ecosystem that does not serialize its values; thus, we needed a way to use cross-storage that did not depend on serialization. This PR adds a configuration option to the client init called `rawMode` that will make getting/setting values not rely on serialization.

Another way to do this would be to use native ES6 classes and create a `rawCrossStorageClient` subclass.

See #21 for more.