### PR TITLE
Prevent memory leaks when calling _request()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -416,6 +416,7 @@
       // Add request callback
       client._requests[req.id] = function(err, result) {
         clearTimeout(timeout);
+        delete client._requests[req.id];
         if (err) return reject(new Error(err));
         resolve(result);
       };


### PR DESCRIPTION
Whenever the _request() function gets called, if the request callback
gets properly called (i.e. it is executed before timeout), the callback
function is never removed from the _requests object. We need to
remove the callbacks when they are executed, otherwise they will keep
accumulating in memory indefinitely.