### PR TITLE
Correct regexp example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ This only restricts access on a per-domain or web app level.
 ``` javascript
 // Config s.t. subdomains can get, but only the root domain can set and del
 CrossStorageHub.init([
-  {origin: /\.example.com$/,            allow: ['get']},
-  {origin: /:\/\/(www\.)?example.com$/, allow: ['get', 'set', 'del']}
+  {origin: /\.example\.com$/,            allow: ['get']},
+  {origin: /:\/\/(www\.)?example\.com$/, allow: ['get', 'set', 'del']}
 ]);
 ```
 


### PR DESCRIPTION
I've just found a little error in the README file :)
